### PR TITLE
Fix truncated document

### DIFF
--- a/AzureRepository/AzureStorage/AzureStorageManager.cs
+++ b/AzureRepository/AzureStorage/AzureStorageManager.cs
@@ -395,7 +395,7 @@ namespace AzureRepositoryPlugin
             {
                 CloudBlockBlob blob = GetBlobContainerFromContainerName(containerName).GetBlockBlobReference(id);
 
-                await blob.UploadFromByteArrayAsync(byteData, 0, data.Length);
+                await blob.UploadFromByteArrayAsync(byteData, 0, byteData.Length);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
If the array of bytes is greater than the parsed json, it results of a truncated document.